### PR TITLE
Octet string

### DIFF
--- a/bin/user/snmp.py
+++ b/bin/user/snmp.py
@@ -357,17 +357,25 @@ class SNMPthread(threading.Thread):
                             if ot=='once':
                                 if tp=='OctetString':
                                     # convert bytes to printable string
+                                    replcs = {
+                                        0:  '',    # NUL \0
+                                        8:  '',    # BS  \b backspace
+                                        9:  '  ',  # TAB \t tabulator
+                                        10: ' ',   # LF  \n line feed
+                                        13: '',    # CR  \r carriage return
+                                        34: '\\"', # "
+                                        92: '\\\\' # \      backslash
+                                    }
                                     val = '"'
                                     for x in varBind[1].asNumbers():
-                                        if x in (0,13):
-                                            # NUL, \r CR
-                                            continue
-                                        elif x==10:
-                                            # \n LF
-                                            val += ' '
+                                        if x in replcs:
+                                            # common control characters
+                                            val += replcs[x]
                                         elif x<32 or x==127:
+                                            # other control charachters
                                             val += '\\x%02X' % x
                                         else:
+                                            # printable characters
                                             val += chr(x)
                                     val += '"'
                                 elif tp=='DisplayString':

--- a/bin/user/snmp.py
+++ b/bin/user/snmp.py
@@ -330,7 +330,7 @@ class SNMPthread(threading.Thread):
                             val = varBind[1]
                             conf = self.conf_dict[ot][ii]
                             if tp in ('DisplayString','OctetString'):
-                                val = weewx.units.ValueTuple(val.prettyPrint(),None,None)
+                                val = weewx.units.ValueTuple(str(val),None,None)
                             elif tp in ('Integer','Integer32','Integer64'):
                                 val = int(val)
                                 if 'conversion' in conf and conf['conversion'] is not None:
@@ -352,7 +352,7 @@ class SNMPthread(threading.Thread):
                             if ot=='once':
                                 val = varBind[1].prettyPrint()
                                 if tp in ('DisplayString','OctetString'):
-                                    val = '"%s"' % val
+                                    val = '"%s"' % str(varBind[1])
                                 loginf("%s %s = %s : %s" % (self.name,
                                   varBind[0].prettyPrint(),
                                   tp,val))

--- a/changelog
+++ b/changelog
@@ -2,3 +2,5 @@
 * initial release
 0.2 07dec2022
 * bug fixes
+0.3
+* better conversion of type OctetString

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class SNMPInstaller(ExtensionInstaller):
     def __init__(self):
         super(SNMPInstaller, self).__init__(
-            version="0.2",
+            version="0.3",
             name='SNMP',
             description='fetch data by SNMP',
             author="Johanna Roedenbeck",


### PR DESCRIPTION
Generally pySNMP displays values of type `OctetString` in hex if they contain non-printable characters and as text otherwise. These changes implement another printing routine that always displays printable characters as characters. CR, LF and TAB characters are replaced by spaces. Other control characters are displayed in hex.